### PR TITLE
Change metadata handling to be compatible with OpenVBI

### DIFF
--- a/wibl-python/examples/ship-metadata-complete.json
+++ b/wibl-python/examples/ship-metadata-complete.json
@@ -1,45 +1,53 @@
 {
-    "trustedNode": {
-        "providerOrganizationName": "",
-        "providerEmail": "",
-        "uniqueVesselID": "",
-        "providerLogger": "",
-        "providerLoggerVersion": "",
-        "verticalReferenceOfDepth": "",
-        "verticalPositionReferencePoint": ""
+    "crs": {
+        "type": "name",
+        "properties": {
+          "name": "EPSG:4269"
+        }
     },
-    "platform": {
-        "length":   0,
-        "IDType":   "",
-        "IDNumber": "",
-        "soundSpeedDocumented":     false,
-        "postionOffsetsDocumented": false,
-        "dataProcessed":            false,
-        "sensors": [
+    "properties": {
+        "trustedNode": {
+            "providerOrganizationName": "",
+            "providerEmail": "",
+            "uniqueVesselID": "",
+            "providerLogger": "",
+            "providerLoggerVersion": "",
+            "verticalReferenceOfDepth": "",
+            "verticalPositionReferencePoint": ""
+        },
+        "platform": {
+            "length": 0,
+            "IDType": "",
+            "IDNumber": "",
+            "soundSpeedDocumented": false,
+            "postionOffsetsDocumented": false,
+            "dataProcessed": false,
+            "sensors": [
+                {
+                    "type": "",
+                    "make": "",
+                    "model": "",
+                    "position": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "version": 0,
+                    "draft": 0.0,
+                    "draftUncert": 0.0,
+                    "frequency": 0.0
+                }
+            ],
+            "contributorComments": ""
+        },
+        "processing": [
             {
                 "type": "",
-                "make": "",
-                "model":    "",
-                "position": [
-                    0.0,
-                    0.0,
-                    0.0
-                ],
-                "version": 0,
-                "draft": 0.0,
-                "draftUncert": 0.0,
-                "frequency": 0.0
+                "timestamp": "",
+                "method": "",
+                "source": "",
+                "algorithm": ""
             }
-        ],
-        "contributorComments": ""
-    },
-    "processing": [
-        {
-            "type": "",
-            "timestamp": "",
-            "method": "",
-            "source": "",
-            "algorithm": ""
-        }
-    ]
+        ]
+    }
 }

--- a/wibl-python/examples/ship-metadata-simple.json
+++ b/wibl-python/examples/ship-metadata-simple.json
@@ -1,17 +1,19 @@
 {
-    "trustedNode": {
-        "providerOrganizationName": "",
-        "providerEmail": "",
-        "uniqueVesselID": "",
-        "providerLogger": "",
-        "providerLoggerVersion": ""
-    },
-    "platform": {
-        "length":   0,
-        "IDType":   "",
-        "IDNumber": "",
-        "soundSpeedDocumented":     false,
-        "postionOffsetsDocumented": false,
-        "dataProcessed":            false
+    "properties": {
+        "trustedNode": {
+            "providerOrganizationName": "",
+            "providerEmail": "",
+            "uniqueVesselID": "",
+            "providerLogger": "",
+            "providerLoggerVersion": ""
+        },
+        "platform": {
+            "length": 0,
+            "IDType": "",
+            "IDNumber": "",
+            "soundSpeedDocumented": false,
+            "postionOffsetsDocumented": false,
+            "dataProcessed": false
+        }
     }
 }

--- a/wibl-python/pyproject.toml
+++ b/wibl-python/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "csbschema~=1.1.2",
     "pygmt~=0.10.0",
     "rasterio~=1.3.0",
-    "geopandas"
+    "geopandas",
+    "deepmerge"
 ]
 
 [project.optional-dependencies]

--- a/wibl-python/requirements-build.txt
+++ b/wibl-python/requirements-build.txt
@@ -7,10 +7,12 @@ pynmea2~=1.18
 csbschema~=1.1.2
 pygmt~=0.10.0
 rasterio~=1.3.0
+geopandas
+deepmerge
 GDAL
 pylint~=3.0.0
 unittest-xml-reporting~=3.2.0
-lxml~=5.0.0
+lxml>=5.3.0
 pytest~=7.4.0
 pytest-cov
 pytest-xdist

--- a/wibl-python/requirements-vizlambda.txt
+++ b/wibl-python/requirements-vizlambda.txt
@@ -11,6 +11,7 @@ GDAL==3.8.2
 fsspec[s3]
 pandas>=2.0.0
 geopandas
+deepmerge
 xarray
 netCDF4
 pylint~=3.0.0

--- a/wibl-python/requirements.txt
+++ b/wibl-python/requirements.txt
@@ -8,3 +8,4 @@ csbschema~=1.1.2
 pygmt~=0.10.0
 rasterio~=1.3.0
 geopandas
+deepmerge

--- a/wibl-python/scripts/convert-md-openvbi.py
+++ b/wibl-python/scripts/convert-md-openvbi.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+import argparse
+import json
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Convert JSON files in a directory to OpenVBI B-12 metadata format'
+    )
+    parser.add_argument('input_dir', type=str,
+                        help='Input directory containing B-12 JSON metadata in WIBL 1.0.4 format')
+    parser.add_argument('output_dir', type=str,
+                        help=('Name of directory to write B-12 JSON metadata in OpenVBI/WIBL 1.1.0 format. '
+                              'If directory does not exist it will be created.')
+                        )
+    args = parser.parse_args()
+
+    input_dir: Path = Path(args.input_dir)
+    if not input_dir.is_dir():
+        sys.exit(f"input_dir {args.input_dir} is not an existing directory, but must be.")
+
+    output_dir: Path = Path(args.output_dir)
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            sys.exit(f"output_dir path {args.output_dir} exists but is not a directory.")
+    else:
+        output_dir.mkdir()
+
+    for ifile in input_dir.glob('*.json'):
+        print(f"In file: {ifile}")
+        ofile: Path = output_dir / ifile.name
+        print(f"\tout file: {ofile}")
+        # Read data
+        try:
+            with open(ifile, mode='r') as f:
+                    src_md: dict = json.load(f)
+        except Exception as e:
+            print(f"Unable to read file {ifile} due to error: {e}, continuing with next file")
+            continue
+
+        # Prepare output data
+        dest_md = {}
+        p = {}
+        dest_md['properties'] = p
+        if 'trustedNode' in src_md:
+            p['trustedNode'] = src_md['trustedNode']
+        if 'platform' in src_md:
+            p['platform'] = src_md['platform']
+        if 'processing' in src_md:
+            p['processing'] = src_md['processing']
+
+        # Write it
+        try:
+            with open(ofile, 'w', encoding='utf-8') as f:
+                json.dump(dest_md, f, indent=4)
+        except Exception as e:
+            print(f"Unable to write file {ofile} due to error: {e}, continuing with next file")
+            continue
+
+    return 0
+
+
+if __name__ == '__main__':
+    main()

--- a/wibl-python/wibl/__init__.py
+++ b/wibl-python/wibl/__init__.py
@@ -8,7 +8,7 @@ from random import randrange
 import argparse
 import logging
 
-__version__ = '1.0.3'
+__version__ = '1.1.0'
 
 
 LOGGER_NAME: str = 'wibl-python'

--- a/wibl-python/wibl/core/geojson_convert.py
+++ b/wibl-python/wibl/core/geojson_convert.py
@@ -35,6 +35,8 @@ import json
 from datetime import datetime, timezone
 from typing import Dict, Any
 
+import deepmerge
+
 from wibl.core import getenv, Lineage
 from wibl.core.algorithm import AlgorithmPhase
 from wibl.core.algorithm.runner import run_algorithms
@@ -127,19 +129,16 @@ def translate(data: Dict[str,Any], lineage: Lineage, filename: str, config: Dict
 
     if data['metadata'] is not None:
         meta = json.loads(data['metadata'])
-        if 'platform' in meta:
-            for k,v in meta['platform'].items():
-                final_json_dict['properties']['platform'][k] = v
-        if 'trustedNode' in meta:
-            for k,v in meta['trustedNode'].items():
-                final_json_dict['properties']['trustedNode'][k] = v
-        if 'processing' in meta:
-            final_json_dict['properties']['processing'] = []
-            for event in meta['processing']:
-                final_json_dict['properties']['processing'].append(event)
-        if 'processing' in final_json_dict['properties'] and len(final_json_dict['properties']['processing']) > 0:
-            final_json_dict['properties']['platform']['dataProcessed'] = True
-    
+        if 'crs' in meta:
+            # If 'crs' metadata have been provided, use that instead of the default defined above in ``final_json_dict``.
+            # Note: we can't just blindly merge elements from the root of ``data['metadata']``
+            # as it could contain a GeoJSON metadata, such as "type" != "FeatureCollection", which would not be valid.
+            final_json_dict['crs'] = meta['crs']
+        if 'properties' in meta:
+            # For the remaining metadata objects stored in properties, simply deep merge these with the defaults
+            # defined above in ``final_json_dict``.
+            deepmerge.always_merger.merge(final_json_dict['properties'], meta['properties'])
+
     # The database requires that the unique ID contains the provider's ID, presumably to avoid
     # namespace clashes.  We therefore check now (after the platform metadata is finalised) to make
     # sure that this is the case.
@@ -168,5 +167,10 @@ def translate(data: Dict[str,Any], lineage: Lineage, filename: str, config: Dict
         if 'processing' not in final_json_dict['properties']:
             final_json_dict['properties']['processing'] = []
         final_json_dict['properties']['processing'] += data['lineage']
+
+    if 'processing' in final_json_dict['properties'] and len(final_json_dict['properties']['processing']) > 0:
+        # Make sure /properties/platform/dataProcessed flag reflects the presence of /properties/processing children
+        # after all potential processing has been done.
+        final_json_dict['properties']['platform']['dataProcessed'] = True
 
     return final_json_dict


### PR DESCRIPTION
This PR changes metadata handling in `wibl-python` when WIBL files are processed into GeoJSON files, as described in #65. This represents initial work to achieve compatibility with OpenVBI by implementing similar metadata handling directly in `wibl-python` code (rather than making OpenVBI a dependency of `wibl-python` and using OpenVBI's metadata handling code directly). This PR also includes an update to documentation in README.md describing the metadata format change, and provides a simple script to convert to the new OpenVBI-compatible format.

In future work, the OpenVBI metadata handling code can be used directly by `wibl-python`. However, doing so will ideally require that OpenVBI first be packaged via conda-forge (since `wibl-python` is also packaged as conda-forge package). However, until this conda packaging work has been done for OpenVBI, the current PR will ensure compatibility.