### PR TITLE
Remove assumption that platform metadata contains IDNumber property.

### DIFF
--- a/wibl-python/wibl/core/datasource.py
+++ b/wibl-python/wibl/core/datasource.py
@@ -572,7 +572,10 @@ class LocalController(CloudController):
                             if self.verbose:
                                 print('error: unrecognised CSB metadata convention.')
                 info['sourceID'] = sourceID
-                info['logger'] = data['properties']['platform']['IDNumber']
+                if 'platform' in data['properties'] and 'IDNumber' in data['properties']['platform']:
+                    info['logger'] = data['properties']['platform']['IDNumber']
+                else:
+                    info['logger'] = 'wibl-logger'
                 info['soundings'] = len(data['features'])
         return meta.localname, info
 


### PR DESCRIPTION
Addresses #69 

Confirmed that the affected change is the only place where 'IDNumber' is explicitly referenced in the wibl-python code.