### PR TITLE
Better error reporting and control in Firmware management website

### DIFF
--- a/LoggerFirmware/ReleaseNotes.md
+++ b/LoggerFirmware/ReleaseNotes.md
@@ -1,5 +1,13 @@
 # Release Notes: Logger Firmware
 
+## Firmware 1.5.4
+
+Firmware 1.5.4 includes the following changes.
+
+* __Management Website Error Reporting__.  This adds reporting of errors (as modal dialog boxes) to the management website so that, e.g., bad JSON files don't cause silent failure in the JavaScript (the JSON is parsed so that it can be stringified) that causes confusion for the user (i.e., the upload appears to fail, but there's no clue as to why).
+* __Management Website Consistency__.  With previous versions of the management website, the configuration JSON was parsed in order from top to bottom of the HTML page.  If the JSON was not in the correct format, this could cause some of the elements in the display to be replaced with default values (often "undefined"), invalidating the configuration, before the parsing failed.  This version of the firmware parses the enable elements first, making it much more likely that a bad configuration file will be detected early.
+* __Consistent Logger Addressing__.  Previous version of the management website JavaScript used a fixed address for the logger when attempting to connect to the REST endpoint for commands.  On the logger's own WAP, this was sufficient, but it fails when the logger joins another WAP as a station.  The code now uses the `location.host` property in JavaScript to parse out the host's name or IP address, and assembles the endpoint URL from there, ensuring that the code adapts to the logger's environment.
+
 ## Firmware 1.5.3
 
 Firmware 1.5.3 includes the following changes:

--- a/LoggerFirmware/include/Configuration.h
+++ b/LoggerFirmware/include/Configuration.h
@@ -38,7 +38,7 @@ namespace logger {
 // Firmware software version (i.e., overall firmware, rather than components like Command Processor, etc.)
 const int firmware_major = 1;
 const int firmware_minor = 5;
-const int firmware_patch = 3;
+const int firmware_patch = 4;
 
 /// @brief Stringify the version information for the firmware itself
 String FirmwareVersion(void);

--- a/LoggerFirmware/website/js/auth.js
+++ b/LoggerFirmware/website/js/auth.js
@@ -25,6 +25,7 @@ function onCertUpload() {
     contents.readAsText(selectedFile);
     contents.onerror = function() {
         console.log(contents.error);
+        window.alert('Failed on load: ' + contents.error.message);
     }
     contents.onload = function() {
         sendCommand('auth cert ' + contents.result).then((data) => {

--- a/LoggerFirmware/website/js/common.js
+++ b/LoggerFirmware/website/js/common.js
@@ -1,5 +1,5 @@
 async function sendCommand(cmdstr, timeout = 10) {
-    const url = 'http://192.168.4.1/command';
+    const url = 'http://' + location.host + '/command';
     let data = new FormData();
     data.append("command", cmdstr);
     let response = await fetch(url, {

--- a/LoggerFirmware/website/js/configuration.js
+++ b/LoggerFirmware/website/js/configuration.js
@@ -103,11 +103,10 @@ function createJSONConfig() {
 }
 
 function parseConfigJSON(config) {
-    document.getElementById("unique-id").value = config.uniqueID;
-    document.getElementById("ship-name").value = config.shipname;
-
-    document.getElementById("bridge-port").value = config.udpbridge;
-
+    /* Checking the enable components first will cause the parse to fail if the JSON isn't
+     * in the right format, and therefore avoid the system resetting other components in
+     * the configuration and over-writing correct values.
+     */
     document.getElementById("nmea0183").checked = config.enable.nmea0183;
     document.getElementById("nmea2000").checked = config.enable.nmea2000;
     document.getElementById("imu").checked = config.enable.imu;
@@ -116,7 +115,12 @@ function parseConfigJSON(config) {
     document.getElementById("nmeabridge").checked = config.enable.udpbridge;
     document.getElementById("webserveronboot").checked = config.enable.webserver;
     document.getElementById("autoupload").value = config.enable.upload;
+    
+    document.getElementById("unique-id").value = config.uniqueID;
+    document.getElementById("ship-name").value = config.shipname;
 
+    document.getElementById("bridge-port").value = config.udpbridge;
+    
     document.getElementById("wifimode").value = config.wifi.mode;
     document.getElementById("retry-delay").value = config.wifi.station.delay;
     document.getElementById("retry-count").value = config.wifi.station.retries;
@@ -172,9 +176,18 @@ function loadConfigLocally() {
     updateText = function() {
         let reader = new FileReader();
         reader.readAsText(input.files[0]);
+        reader.onerror = function() {
+            console.log(reader.error);
+            window.alert('Failed on read: ' + reader.error.message);
+        }
         reader.onload = function() {
-            json = JSON.parse(reader.result);
-            parseConfigJSON(json);
+            try {
+                json = JSON.parse(reader.result);
+                parseConfigJSON(json);
+            } catch (error) {
+                console.log(error);
+                window.alert('Failed on load: ' + error.message);
+            }
         }
     }
     input.onchange = function() {

--- a/LoggerFirmware/website/js/metadata.js
+++ b/LoggerFirmware/website/js/metadata.js
@@ -7,14 +7,20 @@ function onUpload() {
     contents.readAsText(selectedFile);
     contents.onerror = function() {
         console.log(contents.error);
+        window.alert('Failed on read: ' + contents.error.message);
     }
     contents.onload = function() {
-        let dict = JSON.parse(contents.result);
-        let mapDict = JSON.stringify(dict);
-        sendCommand('metadata ' + mapDict).then((data) => {
-            mapDict = JSON.stringify(data, null, 2);
-            document.getElementById("metadata-output").innerHTML = mapDict;
-        });
+        try {
+            let dict = JSON.parse(contents.result);
+            let mapDict = JSON.stringify(dict);
+            sendCommand('metadata ' + mapDict).then((data) => {
+                mapDict = JSON.stringify(data, null, 2);
+                document.getElementById("metadata-output").innerHTML = mapDict;
+            });
+        } catch (error) {
+            console.error(error);
+            window.alert('Failed to upload JSON: ' + error.message);
+        }
     }
 }
 


### PR DESCRIPTION
This PR addresses issue #71 by adding error checking to loading and parsing JSON and other files in the management website.  Failures to load a file, or to parse JSON (for metadata, even though the logger itself doesn't care and just holds whatever file is sent for logging in all raw files) in the JavaScript for the website caused messages to be reported on the console, but not to the user, leading to confusion about what was happening, and failure to update the metadata.  These are now reported in a modal dialog on the client.

This PR also adds automatic parsing for the logger's name/address from the location.host function in the JavaScript, rather than having a fixed address (appropriate on the logger's own WAP, but not if the logger's on another system).