### PR TITLE
wibl-python: 1.2.0 release 

### DIFF
--- a/wibl-python/pyproject.toml
+++ b/wibl-python/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "Python code WIBL low-cost data logger system"
 license = { file = "LICENSE.txt" }
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: Other/Proprietary License",

--- a/wibl-python/src/wibl/__init__.py
+++ b/wibl-python/src/wibl/__init__.py
@@ -8,7 +8,7 @@ from random import randrange
 import argparse
 import logging
 
-__version__ = '1.2.0.dev1'
+__version__ = '1.2.0'
 
 
 LOGGER_NAME: str = 'wibl-python'


### PR DESCRIPTION
The following release notes will be included in the release tag:

[Changes since 1.1.1 release (May 8th, 2025)](https://github.com/CCOMJHC/WIBL/commits/?path=wibl-python&since=2025-05-09&until=2026-01-07)
  - Notable changes:
    - Use wibl@ccom.unh.edu as e-mail for example metadata ([commit](https://github.com/CCOMJHC/WIBL/commit/7219cc7cdc9e748125749531b9dd20a4bdef8466)).
    - Add strict mode support for commands that read WIBL files to allow failed packet transcriptions to be treated as an error. By default, strict mode is not enabled. Previous default was to treat packet transcription errors as fatal errors. New default is to treat these are warnings with a detailed explanation of exactly where the fault lies in the WIBL file being processed. ([commit](https://github.com/CCOMJHC/WIBL/commit/a53e63d660b1266f5313eaa82b6041b6e0b5c33d)).
    - logger-file: when reading WIBL packets record position before read so that byte offset reported during error will be more precise ([commit](https://github.com/CCOMJHC/WIBL/commit/8e2cb042eef8db59cb312a746dbff2703236aa0d).
    - Update CLI application to use [click](https://click.palletsprojects.com/) ([commit](https://github.com/CCOMJHC/WIBL/commit/34455508027d986ba2d90fcd3e80d4f6bf09f9a3).
    - Testing improvements
      - Update integration test to add `validate` command ([commit](https://github.com/CCOMJHC/WIBL/commit/34455508027d986ba2d90fcd3e80d4f6bf09f9a3)).
      - Update test suite metadata to conform to B-12 3.1 ([commit](https://github.com/CCOMJHC/WIBL/commit/34455508027d986ba2d90fcd3e80d4f6bf09f9a3)).
      - Add localstack docker config for automated testing of uploadwibl without cloud ([commit](https://github.com/CCOMJHC/WIBL/commit/149aeda6e9d527724cba2180235ec59334a07454)).