### PR TITLE
Feature: Support WPA3/SAE and PMF configuration for modern hotspots (#111)

### DIFF
--- a/LoggerFirmware/include/Configuration.h
+++ b/LoggerFirmware/include/Configuration.h
@@ -99,7 +99,8 @@ class Config {
             CONFIG_UPLOAD_INTERVAL_S,/* String: interval (seconds) between upload attempts */
             CONFIG_UPLOAD_DURATION_S,/* String: duration (seconds) for each upload event */
             CONFIG_UPLOAD_CERT_S,   /* String: certificate to pass to upload server for authentication */
-            CONFIG_MDNS_NAME_S      /* String: recognition name for mDNS responder (hostname: name.local) */
+            CONFIG_MDNS_NAME_S,     /* String: recognition name for mDNS responder (hostname: name.local) */
+            CONFIG_REQUIRE_PMF_S    /* String: Require PMF for WPA3 connections (true/false) */
         };
 
         /// \brief Extract a configuration string for the specified parameter

--- a/LoggerFirmware/src/Configuration.cpp
+++ b/LoggerFirmware/src/Configuration.cpp
@@ -86,7 +86,8 @@ const String lookup[] = {
     "UploadInterval",   ///< Interval (seconds) between upload attempts
     "UploadDuration",   ///< Time (seconds) for upload activity before diverting back to other efforts
     "UploadCert",       ///< Certificate to pass to the upload server for TLS
-    "mDNSName"
+    "mDNSName",
+    "RequirePMF"        ///< Require PMF for WPA3 (string)
 };
 
 /// Default constructor.  This sets up for a dummy parameter store, which is configured

--- a/LoggerFirmware/src/WiFiAdapter.cpp
+++ b/LoggerFirmware/src/WiFiAdapter.cpp
@@ -31,6 +31,7 @@
 #include <WiFiAP.h>
 #include <ESPmDNS.h>
 #include <WebServer.h>
+#include <esp_wifi.h>
 #include <WifiClient.h>
 #include <LittleFS.h>
 #include <ESP32-targz.h>
@@ -322,6 +323,25 @@ private:
             Serial.print("ERR: attempting to join a WiFi network as a station without a specified SSID\n");
             return false;
         }
+
+        // Configure WPA3/PMF fallback & parameters for modern hotspots
+        WiFi.mode(WIFI_STA);
+        wifi_config_t conf;
+        esp_wifi_get_config(WIFI_IF_STA, &conf);
+        
+        bool require_pmf = false;
+        String require_pmf_str;
+        if (logger::LoggerConfig.GetConfigString(logger::Config::ConfigParam::CONFIG_REQUIRE_PMF_S, require_pmf_str)) {
+            require_pmf = require_pmf_str.equalsIgnoreCase("true") || require_pmf_str == "1";
+        }
+        
+        conf.sta.pmf_cfg.capable = true;
+        conf.sta.pmf_cfg.required = require_pmf;
+#ifdef WPA3_SAE_PWE_BOTH
+        conf.sta.sae_pwe_h2e = WPA3_SAE_PWE_BOTH;
+#endif
+        esp_wifi_set_config(WIFI_IF_STA, &conf);
+
         wl_status_t status = WiFi.begin(ssid.c_str(), password.c_str());
         WiFi.setSleep(false);
         m_lastConnectAttempt = millis();

--- a/LoggerFirmware/src/WiFiAdapter.cpp
+++ b/LoggerFirmware/src/WiFiAdapter.cpp
@@ -335,6 +335,10 @@ private:
             require_pmf = require_pmf_str.equalsIgnoreCase("true") || require_pmf_str == "1";
         }
         
+        if (m_verbose) {
+            Serial.printf("DBG: WPA3 PMF configured as %s\n", require_pmf ? "REQUIRED" : "CAPABLE-ONLY");
+        }
+
         conf.sta.pmf_cfg.capable = true;
         conf.sta.pmf_cfg.required = require_pmf;
 #ifdef WPA3_SAE_PWE_BOTH


### PR DESCRIPTION
Resolves #111 

**Description**
When utilizing the WIBL logger with modern mobile hotspots (e.g. Google Pixel 9 Pro) that enforce WPA3 security, the logger was failing to authenticate. This PR fixes this by configuring PMF (\pmf_cfg.capable\, \pmf_cfg.required\) and WPA3 SAE flags prior to invoking \WiFi.begin()\.

**Changes**
- Injects WPA3 / PMF capabilities in \WiFiAdapter::attemptStationJoin\.
- Adds a \RequirePMF\ parameter to the configuration system so strict PMF enforcement can be toggled without breaking legacy WPA2 infrastructure. By default, WPA2 backward compatibility is strictly retained.
