### PR TITLE
Fix: build script apply_patches.py relies on global system Python

### DIFF
--- a/LoggerFirmware/apply_patches.py
+++ b/LoggerFirmware/apply_patches.py
@@ -20,7 +20,7 @@ files_were_patched = False
 for patch_file, original_file in patches.items():
     print(f"\tApplying patch '{patch_file}' to file '{original_file}'")
     assert original_file.is_file() and patch_file.is_file()
-    res = env.Execute(f"python patch.py -d {str(original_file.parent)} {str(patch_file)}")
+    res = env.Execute(f'"{sys.executable}" patch.py -d {str(original_file.parent)} {str(patch_file)}')
     if res == 0:
         print(f"\t\tSuccessfully applied patch '{patch_file}'")
         files_were_patched = True


### PR DESCRIPTION
Resolves #115

When building LoggerFirmware on Windows, PlatformIO executes apply_patches.py. This script previously spawned a shell and explicitly invoked python, which expects the system's global $PATH to map to a compatible Python interpreter.

On some systems (particularly Windows), this can invoke the wrong interpreter, trigger the Microsoft Store 'Install Python' prompt, or error out.

**Fix**
By swapping the hardcoded python string for Python's own standard sys.executable, the script dynamically references the exact Python interpreter instance that PlatformIO is already running inside (e.g. .platformio/penv/Scripts/python.exe). This helps improve cross-platform robustness.
