### PR TITLE
Filter by NMEA2000 talker ID

### DIFF
--- a/wibl-python/README.md
+++ b/wibl-python/README.md
@@ -318,11 +318,23 @@ inability to read data packets from WIBL files will be treated as an error, caus
 behavior of all commands that read WIBL files is to disable strict mode, so that processing will continue if one or
 more data packets cannot be read.
 
+The `bad_talkers` list can be used to ignore individual NMEA2000 devices by
+their talker ID during processing (`procwibl`) into GeoJSON filtes.  This should
+be a comma-separated list of the integer talker IDs reported by `parsewibl`;
+since these IDs can be reconfigured when you add new devices to the network,
+they can't be reliably filtered at capture; at processing, you can review the
+talker IDs and add them to the custom list if required.
+
 > Note on configuration files: It is no longer necessary to set `local` to `true` when running
 > `procwibl`. This setting is only used by the `validate` command. See below.
 
 ### Upload WIBL files into AWS S3 Buckets for processing
-Instead of using the mobile app (and for testing), WIBL binary files can be uploaded into a given S3 bucket to trigger processing.  If the file is being uploaded into the staging bucket (i.e., to test transfer to DCDB), a '.json' extension must be added (``-j|--json``), and the SourceID tag must be set (``-s|--source``) so that the submission Lambda can find this information.
+
+Instead of using the mobile app (and for testing), WIBL binary files can be
+uploaded into a given S3 bucket to trigger processing.  If the file is being
+uploaded into the staging bucket (i.e., to test transfer to DCDB), a '.json'
+extension must be added (``-j|--json``), and the SourceID tag must be set
+(``-s|--source``) so that the submission Lambda can find this information.
 ```
 $ wibl uploadwibl --help
 Usage: wibl uploadwibl [OPTIONS] INPUT

--- a/wibl-python/examples/configure-submission-test.json
+++ b/wibl-python/examples/configure-submission-test.json
@@ -6,5 +6,6 @@
 	"strict_mode": 			false,
 	"provider_id": 			"UNHJHC",
 	"management_url": 		"",
-  	"upload_point": 		"https://www.ngdc.noaa.gov/ingest-external/upload/csb/test/geojson/"
+  	"upload_point": 		"https://www.ngdc.noaa.gov/ingest-external/upload/csb/test/geojson/",
+	"bad_talkers":			[]
 }

--- a/wibl-python/examples/configure-submission.json
+++ b/wibl-python/examples/configure-submission.json
@@ -6,5 +6,6 @@
 	"strict_mode": 			false,
 	"provider_id": 			"UNHJHC",
 	"management_url": 		"",
-  	"upload_point": 		"https://www.ngdc.noaa.gov/ingest-external/upload/csb/geojson/"
+  	"upload_point": 		"https://www.ngdc.noaa.gov/ingest-external/upload/csb/geojson/",
+	"bad_talkers":			[]
 }

--- a/wibl-python/src/wibl/__init__.py
+++ b/wibl-python/src/wibl/__init__.py
@@ -3,7 +3,7 @@ import sys
 from importlib import resources
 from typing import Optional, TextIO
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, UTC
 from random import randrange
 import argparse
 import logging
@@ -17,7 +17,7 @@ _logger: logging.Logger = logging.getLogger(LOGGER_NAME)
 
 
 def get_logfile_name(prefix: str = 'wibl-python-', suffix: str = 'log') -> str:
-    date_portion = datetime.utcnow().strftime("%Y-%m-%dT%H_%M_%S.%fZ")
+    date_portion = datetime.now(UTC).strftime("%Y-%m-%dT%H_%M_%S.%fZ")
     rand_portion = f"{randrange(1, 10000):05}"
     return f"{prefix}{date_portion}-{rand_portion}.{suffix}"
 
@@ -80,7 +80,7 @@ def config_logger(*,
 
 
 def config_logger_cmdline(args: argparse.Namespace, *,
-                          log_prefix: str = None) -> logging.Logger:
+                          log_prefix: str|None = None) -> logging.Logger:
     """
     Configure global logger instance and return it. For use by
     command line tools.

--- a/wibl-python/src/wibl/command/parse_wibl_file.py
+++ b/wibl-python/src/wibl/command/parse_wibl_file.py
@@ -57,6 +57,7 @@ def parsewibl(input: str, stats: bool, dump: str, strict_mode: bool):
     packet_count: int = 0
     packet_stats: dict = {}
     source = LoggerFile.PacketFactory(file, strict_mode=strict_mode)
+    packets_by_source: dict[int,dict[str,int]] = dict()
     while source.has_more():
         try:
             pkt = source.next_packet()
@@ -65,11 +66,20 @@ def parsewibl(input: str, stats: bool, dump: str, strict_mode: bool):
                 click.echo(pkt)
                 if dump_file:
                     if pkt.name() == 'SerialString':
+                        assert(type(pkt) == LoggerFile.SerialString)
                         dump_file.write(f'{pkt.elapsed} {pkt.data.decode("utf-8").strip()}\n')
                 if stats:
                     if pkt.name() not in packet_stats:
                         packet_stats[pkt.name()] = 0
                     packet_stats[pkt.name()] += 1
+                    talker: int = getattr(pkt, 'talker_id', -1)
+                    if talker >= 0:
+                        if talker not in packets_by_source:
+                            packets_by_source[talker] = dict()
+                        packet_name = pkt.name()
+                        if packet_name not in packets_by_source[talker]:
+                            packets_by_source[talker][packet_name] = 0
+                        packets_by_source[talker][packet_name] += 1
         except LoggerFile.PacketTranscriptionError as e:
             sys.exit(f"Failed to translate packet {packet_count}: {str(e)}.")
 
@@ -78,3 +88,9 @@ def parsewibl(input: str, stats: bool, dump: str, strict_mode: bool):
         click.echo("Packet statistics:")
         for name in packet_stats:
             click.echo(f"\t{packet_stats[name]:8d} {name}")
+        click.echo("Packet statistics by talker:")
+        talkers = [t for t in packets_by_source]
+        talkers.sort()
+        for talker in talkers:
+            packets = [f'{name}({packets_by_source[talker][name]})' for name in packets_by_source[talker]]
+            click.echo(f"\t{talker:3d}: {' '.join(packets)}")

--- a/wibl-python/src/wibl/command/validate.py
+++ b/wibl-python/src/wibl/command/validate.py
@@ -40,7 +40,7 @@ from wibl.validation.cloud.aws.lambda_function import validate_metadata
 @click.option('-c', '--config',
               type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
               help='Specify configuration file for installation')
-def geojson_validate(input: str, config: Path=None):
+def geojson_validate(input: str, config: Path):
     """Validate GeoJSON metadata stored in INPUT."""
     infilename = input
 

--- a/wibl-python/src/wibl/command/wibl_proc.py
+++ b/wibl-python/src/wibl/command/wibl_proc.py
@@ -46,14 +46,14 @@ from wibl.core.notification import LocalNotifier
 @click.option('-c', '--config',
               type=click.Path(exists=True), required=True,
               help='Specify configuration file for installation')
-def wibl_proc(input: Path, output: Path, config: Path=None):
+def wibl_proc(input: Path, output: Path, config: Path):
     """Process a WIBL file INPUT into GeoJSON file OUTPUT locally."""
     infilename = str(input)
     outfilename = str(output)
 
     try:
         cfg = conf.read_config(config)
-        if 'notification' not in config:
+        if 'notification' not in cfg:
             cfg['notification'] = {}
         if 'converted' not in cfg['notification']:
             cfg['notification']['converted'] = ''

--- a/wibl-python/src/wibl/core/config.py
+++ b/wibl-python/src/wibl/core/config.py
@@ -92,7 +92,7 @@ def get_config_file(resource_name, env_key: str = DEFAULT_CONFIG_FILE_ENV_KEY) -
     return get_config_path(get_config_resource_filename(resource_name), env_key)
 
 
-def read_config(config_file: Union[Path, str] = None) -> Dict[str, Any]:
+def read_config(config_file: Union[Path, str]) -> Dict[str, Any]:
     """There are a number of configuration parameters for the algorithm, such as the provider ID name
        to write into the metadata, and use for filenames; where to stage the intermediate GeoJSON files
        before they're uploaded to the database; and where to send the files.  There are also parameters

--- a/wibl-python/src/wibl/core/fileloader.py
+++ b/wibl-python/src/wibl/core/fileloader.py
@@ -120,7 +120,8 @@ def determine_time_source(stats: PktStats) -> TimeSource:
 # \return Tuple of PktStats, TimeSource, a list of DataPacket, and a list of AlgorithmDescriptor entries from the file
 def load_file(filename: str, lineage: Lineage, verbose: bool, maxreports: int, *,
               process_algorithms: bool = True,
-              strict_mode: bool = False) -> \
+              strict_mode: bool = False,
+              bad_talkers: list[int]|None = None) -> \
         Tuple[PktStats, TimeSource, List[LoggerFile.DataPacket], List[AlgorithmDescriptor]]:
     """Load the entirety of a WIBL binary file into memory, in the process determining the type of time
        source that can be used to add timestamps to the data, and fixing up any messages that don't have
@@ -134,6 +135,7 @@ def load_file(filename: str, lineage: Lineage, verbose: bool, maxreports: int, *
             verbose         Flag: set True to extra information on the process
             maxreports      Maximum number of errors per packet to report before summarising
             process_algorithms Flag: set to True to enable execution of algorithms for phase `AlgorithmPhaseON_LOAD`
+            bad_talkers     List of talker IDs to drop from the input stream, or None
 
         Outputs:
             stats           (PktStats) Statistics on which packets have been seen, and any problems
@@ -153,7 +155,18 @@ def load_file(filename: str, lineage: Lineage, verbose: bool, maxreports: int, *
         while source.has_more():
             pkt = source.next_packet()
             if pkt is not None:
-                packets_raw.append(pkt)
+                if bad_talkers is not None:
+                    talker_id = getattr(pkt, 'talker_id', -1)
+                    if talker_id >= 0:
+                        # A talker is specified, so we need to attempt to filter
+                        if talker_id in bad_talkers:
+                            stats.Fault(pkt.name(), PktFaults.FilteredFault)
+                        else:
+                            packets_raw.append(pkt)
+                    else:
+                        packets_raw.append(pkt)
+                else:
+                    packets_raw.append(pkt)
                 # Check for algorithm packet
                 if isinstance(pkt, LoggerFile.AlgorithmRequest):
                     stats.Observed(pkt.name())

--- a/wibl-python/src/wibl/core/statistics.py
+++ b/wibl-python/src/wibl/core/statistics.py
@@ -52,6 +52,8 @@ class PktFaults(Enum):
     TypeFault = 4
     ## A fault in checksum verification for a packet
     ChecksumFault = 5
+    ## Filtered by talker ID
+    FilteredFault = 6
 
 ## Exception indicating that the code attempted to register an unknown fault type
 class NoSuchFault(Exception):
@@ -72,6 +74,7 @@ class StatCounters:
     attrib_fault:   int = 0
     type_fault:     int = 0
     chksum_fault:   int = 0
+    filtered_fault: int = 0
 
     ## Count the number of times that the object has been observed in the datastream
     def Observed(self) -> None:
@@ -101,6 +104,10 @@ class StatCounters:
     def ChecksumFault(self) -> None:
         self.chksum_fault += 1
 
+    ## Count the number of times an object has been filtered by talker
+    def FilteredFault(self) -> None:
+        self.filtered_fault += 1
+
     ## Count the total number of faults that have been seen on the object
     #
     # For reporting purposes, it's often a requirement to know how many faults have been
@@ -109,12 +116,12 @@ class StatCounters:
     #
     # \return Total number of faults recorded for this object
     def FaultCount(self) -> int:
-        return self.parse_fault + self.short_msg + self.decode_fault + self.attrib_fault + self.type_fault + self.chksum_fault
+        return self.parse_fault + self.short_msg + self.decode_fault + self.attrib_fault + self.type_fault + self.chksum_fault + self.filtered_fault
 
     ## Generate a printable representation of the current object's information
     def __str__(self) -> str:
         total_fault = self.FaultCount()
-        rtn = f'{self.observed:6} Obs.; Errors ({total_fault:6} total): {self.parse_fault:6} Parse / {self.short_msg:6} Short / {self.decode_fault:6} Decode / {self.attrib_fault:6} Attrib / {self.type_fault:6} Type / {self.chksum_fault:6} Checksum'
+        rtn = f'{self.observed:6} Obs.; Errors ({total_fault:6} total): {self.parse_fault:6} Parse / {self.short_msg:6} Short / {self.decode_fault:6} Decode / {self.attrib_fault:6} Attrib / {self.type_fault:6} Type / {self.chksum_fault:6} Checksum / {self.filtered_fault:6} Filtered'
         return rtn
 
 ## \class PktStats
@@ -183,6 +190,8 @@ class PktStats:
             self.packets[name].TypeFault()
         elif fault == PktFaults.ChecksumFault:
             self.packets[name].ChecksumFault()
+        elif fault == PktFaults.FilteredFault:
+            self.packets[name].FilteredFault()
         else:
             raise NoSuchFault()
 

--- a/wibl-python/src/wibl/core/timestamping.py
+++ b/wibl-python/src/wibl/core/timestamping.py
@@ -90,7 +90,7 @@ def protocol_version(major: int, minor: int) -> int:
 ## Latest major protocol version understood by the code
 protocol_version_major = 1
 ## Latest minor protocol version understood by the code
-protocol_version_minor = 3
+protocol_version_minor = 4
  
 ## Maximum protocol version understood by the code
 maximum_version = protocol_version(protocol_version_major, protocol_version_minor)
@@ -126,12 +126,17 @@ def time_interpolation(filename: str, lineage: Lineage, elapsed_time_quantum: in
         strict_mode = kwargs['strict_mode']
     else:
         strict_mode = False
+    if 'bad_talkers' in kwargs:
+        bad_talkers = kwargs['bad_talkers']
+    else:
+        bad_talkers = []
     
     # Pull all of the packets out of the file, and fix up any preliminary problems
     try:
         stats, time_source, packets, algorithms = load_file(filename, lineage, verbose, fault_limit,
                                                             process_algorithms=process_algorithms,
-                                                            strict_mode=strict_mode)
+                                                            strict_mode=strict_mode,
+                                                            bad_talkers=bad_talkers)
     except flNoTimeSource as e:
         if verbose:
             print(f'Failed to determine a valid time source from file: {e}')

--- a/wibl-python/src/wibl/processing/cloud/aws/lambda_function.py
+++ b/wibl-python/src/wibl/processing/cloud/aws/lambda_function.py
@@ -73,6 +73,7 @@ def process_item(item: ds.DataItem, controller: ds.CloudController, notifier: nt
 
     verbose: bool = config['verbose']
     strict_mode: bool = config['strict_mode']
+    bad_talkers: list[int] = config['bad_talkers']
 
     meta: WIBLMetadata = WIBLMetadata()
     lineage: Lineage = Lineage()
@@ -93,7 +94,8 @@ def process_item(item: ds.DataItem, controller: ds.CloudController, notifier: nt
         source_data = ts.time_interpolation(local_file, lineage, config['elapsed_time_quantum'],
                                             verbose=verbose,
                                             fault_limit=config['fault_limit'],
-                                            strict_mode=strict_mode)
+                                            strict_mode=strict_mode,
+                                            bad_talkers=bad_talkers)
         meta.logger = source_data['loggername']
         meta.platform = source_data['platform']
         meta.observations = len(source_data['depth']['z'])


### PR DESCRIPTION
This closes #51 by adding the ability to filter NMEA2000 packets by talker ID during the processing of WIBL files into GeoJSON.  The packets are filtered out at the initial conversion of WIBL into internal structure so that they don't corrupt the lookup tables, etc., before timestamp interpolation.  This allows the user to specify particular devices on the NMEA2000 network that should be ignored (generally because they're making duff data).

This code is part of FW 1.7.0, and should be merged after #119.